### PR TITLE
Fix typo in transitive dependency example

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Then it is really easy to bind RandomDice with it's transitive dependencies, by 
 ```kotlin
 bind<Random>() with provider { SecureRandom() }
 constant("max") with 5
-bind<Dice>() with { Dice(instance(), instance("max")) }
+bind<Dice>() with singleton { Dice(instance(), instance("max")) }
 ```
 
 You can, of course, also use the functions `provider()`, `provider(tag)`, `factory()` and `factory(tag)`, 


### PR DESCRIPTION
Unless I'm misunderstanding something, it appears that `singleton` was missing from the example, since it seems that `bind... with` cannot directly be given a lambda, but needs to be given a factory like `singleton`