### PR TITLE
Fixed some doc typos

### DIFF
--- a/README2.md
+++ b/README2.md
@@ -249,7 +249,7 @@ Note that you can have multiple bindings of the same type, as long as they are b
 
 ### Constant binding
 
-It is often useful to bind "configuration" constants. These contants are always tagged:
+It is often useful to bind "configuration" constants. These constants are always tagged:
 
 ```kotlin
 val kodein = Kodein {
@@ -298,7 +298,7 @@ class Dice(private val random: Random, private val sides: Int) {
 }
 ```
 
-Then it is really easy to bind RandomDice with it's transitive dependencies, by simply using `instance()` or `instance(tag)`:
+Then it is really easy to bind RandomDice with its transitive dependencies, by simply using `instance()` or `instance(tag)`:
 
 ```kotlin
 val kodein = Kodein {
@@ -470,7 +470,7 @@ An injector is an object that you can use to inject all injected values in an ob
 
 This allows your object to:
 
- - Retrieve all it's injected dependencies at once;
+ - Retrieve all its injected dependencies at once;
  - Declare its dependencies without a Kodein instance.
 
 ```kotlin
@@ -796,7 +796,7 @@ val logger: Logger = kodein.instance()
 Bind the same type to different factories
 -----------------------------------------
 
-Yeah, when I said earlier that "you can have multiple bindings of the same type, as long as they are binded with different tags", I lied. Because each binding is actually a factory, the bindings are not `([BindType], [Tag])` but actually `([BindType], [ArgType], [Tag])` (note that providers and singletons are binded as `([BindType], Unit, [Tag])`). This means that any combination of these three information can be binded to it's own factory, which in turns means that you can bind the same type without tagging to different factories. Please be cautious when using this knowledge, as other less thorough readers may get confused with it.
+Yeah, when I said earlier that "you can have multiple bindings of the same type, as long as they are binded with different tags", I lied. Because each binding is actually a factory, the bindings are not `([BindType], [Tag])` but actually `([BindType], [ArgType], [Tag])` (note that providers and singletons are binded as `([BindType], Unit, [Tag])`). This means that any combination of these three information can be binded to its own factory, which in turns means that you can bind the same type without tagging to different factories. Please be cautious when using this knowledge, as other less thorough readers may get confused with it.
 
 
 

--- a/README3.adoc
+++ b/README3.adoc
@@ -222,7 +222,7 @@ TIP: The tag is of type `Any`, it does not have to be a `String`.
 === Constant binding
 
 It is often useful to bind "configuration" constants.
-Contants are always tagged.
+Constants are always tagged.
 
 [source,kotlin]
 .Example: two constants
@@ -273,7 +273,7 @@ class Dice(private val random: Random, private val sides: Int) {
 }
 ----
 
-It is really easy to bind `RandomDice` with it's transitive dependencies, by simply using `instance()` or `instance(tag)`.
+It is really easy to bind `RandomDice` with its transitive dependencies, by simply using `instance()` or `instance(tag)`.
 
 [source, kotlin]
 .Example: bindings of Dice and of its transitive dependencies
@@ -527,7 +527,7 @@ private val randomSideDiceProvider: () -> Dice
 An injector is an object that you can use to inject all dependency properties in an object.
 
 .This allows your object to:
-* Retrieve all it's injected dependencies at once;
+* Retrieve all its injected dependencies at once;
 * Declare its dependencies without a Kodein instance.
 
 [source, kotlin]
@@ -732,7 +732,7 @@ class JavaClass {
 
 == Configurable Kodein
 
-Maybe you want a Kodein instance that you can pass around and have different sections of your code configure it's bindings.
+Maybe you want a Kodein instance that you can pass around and have different sections of your code configure its bindings.
 
 Configurable Kodein is a Kodein extension that is not proposed  _by default_, this paradigm is in a separate module.
 


### PR DESCRIPTION
"contants" -> "constants"

"it's" (with apostrophe) means "it is".  "its" (no apostrophe) is the possessive form of "it". http://its-not-its.info/

Trivial, of course, but distracting.