### PR TITLE
Fix typos and use nicer Kotlin API instead of java.lang + warning suppression

### DIFF
--- a/README2.md
+++ b/README2.md
@@ -538,7 +538,7 @@ Kodein does work on Android (in fact, it was developed for an Android project). 
 
 Here's how to use `kodein-android`: declare the dependency bindings in the Android `Application`, having it implements `KodeinApplication`:
 
-```kotin
+```kotlin
 class MyApp : Application(), KodeinApplication {
 	override val kodein = Kodein {
 	/* bindings... */

--- a/kodein/src/main/kotlin/com/github/salomonbrys/kodein/typeDisp.kt
+++ b/kodein/src/main/kotlin/com/github/salomonbrys/kodein/typeDisp.kt
@@ -59,14 +59,14 @@ private object FullTypeStringer : TypeStringer() {
     override fun dispName(cls: Class<*>) = when {
         cls.isArray -> "Array<" + dispString(cls.componentType) + ">"
         cls.enclosingClass != null -> dispString(cls.enclosingClass) + "." + cls.simpleName
-        cls == java.lang.Boolean::class.java -> "kotin.Boolean"
-        cls == java.lang.Byte::class.java -> "kotin.Byte"
-        cls == java.lang.Character::class.java -> "kotin.Char"
-        cls == java.lang.Short::class.java -> "kotin.Short"
-        cls == java.lang.Integer::class.java -> "kotin.Int"
-        cls == java.lang.Long::class.java -> "kotin.Long"
-        cls == java.lang.Float::class.java -> "kotin.Float"
-        cls == java.lang.Double::class.java -> "kotin.Double"
+        cls == java.lang.Boolean::class.java -> "kotlin.Boolean"
+        cls == java.lang.Byte::class.java -> "kotlin.Byte"
+        cls == java.lang.Character::class.java -> "kotlin.Char"
+        cls == java.lang.Short::class.java -> "kotlin.Short"
+        cls == java.lang.Integer::class.java -> "kotlin.Int"
+        cls == java.lang.Long::class.java -> "kotlin.Long"
+        cls == java.lang.Float::class.java -> "kotlin.Float"
+        cls == java.lang.Double::class.java -> "kotlin.Double"
         else -> cls.`package`.name + "." + SimpleTypeStringer.dispName(cls)
     }
 }

--- a/kodein/src/main/kotlin/com/github/salomonbrys/kodein/typeDisp.kt
+++ b/kodein/src/main/kotlin/com/github/salomonbrys/kodein/typeDisp.kt
@@ -41,33 +41,35 @@ private abstract class TypeStringer {
  * Type stringer that displays simple type names.
  */
 private object SimpleTypeStringer : TypeStringer() {
-    @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
     override fun dispName(cls: Class<*>): String = when {
         cls.isArray -> "Array<" + dispString(cls.componentType) + ">"
         cls.enclosingClass != null -> dispName(cls.enclosingClass) + "." + cls.simpleName
-        cls == java.lang.Character::class.java -> "Char"
-        cls == java.lang.Integer::class.java -> "Int"
-        else -> cls.simpleName
+        else -> cls.primitiveName ?: cls.simpleName
     }
 }
+
+private val Class<*>.primitiveName: String?
+    get() = when (this) {
+        Boolean::class.javaPrimitiveType, Boolean::class.javaObjectType -> "Boolean"
+        Byte::class.javaPrimitiveType, Byte::class.javaObjectType -> "Byte"
+        Character::class.javaPrimitiveType, Character::class.javaObjectType -> "Char"
+        Short::class.javaPrimitiveType, Short::class.javaObjectType -> "Short"
+        Integer::class.javaPrimitiveType, Integer::class.javaObjectType -> "Int"
+        Long::class.javaPrimitiveType, Long::class.javaObjectType -> "Long"
+        Float::class.javaPrimitiveType, Float::class.javaObjectType -> "Float"
+        Double::class.javaPrimitiveType, Double::class.javaObjectType -> "Double"
+        else -> null
+    }
 
 /**
  * Type stringer that displays full type names.
  */
 private object FullTypeStringer : TypeStringer() {
-    @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
     override fun dispName(cls: Class<*>) = when {
         cls.isArray -> "Array<" + dispString(cls.componentType) + ">"
         cls.enclosingClass != null -> dispString(cls.enclosingClass) + "." + cls.simpleName
-        cls == java.lang.Boolean::class.java -> "kotlin.Boolean"
-        cls == java.lang.Byte::class.java -> "kotlin.Byte"
-        cls == java.lang.Character::class.java -> "kotlin.Char"
-        cls == java.lang.Short::class.java -> "kotlin.Short"
-        cls == java.lang.Integer::class.java -> "kotlin.Int"
-        cls == java.lang.Long::class.java -> "kotlin.Long"
-        cls == java.lang.Float::class.java -> "kotlin.Float"
-        cls == java.lang.Double::class.java -> "kotlin.Double"
-        else -> cls.`package`.name + "." + SimpleTypeStringer.dispName(cls)
+        else -> cls.primitiveName?.let { "kotlin.$it" }
+                ?: cls.`package`.name + "." + SimpleTypeStringer.dispName(cls)
     }
 }
 

--- a/kodein/src/test/kotlin/com/github/salomonbrys/kodein/test/test.kt
+++ b/kodein/src/test/kotlin/com/github/salomonbrys/kodein/test/test.kt
@@ -580,8 +580,7 @@ class KodeinTests : TestCase() {
         assertEquals("singleton", kodein.container.bindings[Kodein.Key(Kodein.Bind(IPerson::class.java, "singleton"), Unit::class.java)]?.factoryName)
         assertEquals("factory", kodein.container.bindings[Kodein.Key(Kodein.Bind(IPerson::class.java, "factory"), String::class.java)]?.factoryName)
         assertEquals("instance", kodein.container.bindings[Kodein.Key(Kodein.Bind(IPerson::class.java, "instance"), Unit::class.java)]?.factoryName)
-        @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
-        assertEquals("instance", kodein.container.bindings[Kodein.Key(Kodein.Bind(Integer::class.java, "answer"), Unit::class.java)]?.factoryName)
+        assertEquals("instance", kodein.container.bindings[Kodein.Key(Kodein.Bind(Int::class.javaObjectType, "answer"), Unit::class.java)]?.factoryName)
     }
 
     @Test fun test16_1_ScopedSingleton() {


### PR DESCRIPTION
There are two functions in stdlib specifically introduced to be able to get corresponding Class objects for primitives: [javaObjectType](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/java-object-type.html) and [javaPrimitiveType](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/java-primitive-type.html). I've changed some code to use them instead of the old `java.lang.X::class.java` which requires a warning suppressed. I've noticed that the changed code is used only for debug, so no new tests were added.