### PR TITLE
WIP: Architecture changes

### DIFF
--- a/kodein/src/main/kotlin/com/github/salomonbrys/kodein/factories.kt
+++ b/kodein/src/main/kotlin/com/github/salomonbrys/kodein/factories.kt
@@ -67,18 +67,16 @@ inline fun <reified T : Any> Kodein.Builder.provider(noinline creator: Kodein.()
  */
 abstract class ASingleton<out T : Any>(factoryName: String, createdType: Type, val creator: Kodein.() -> T) : AProvider<T>(factoryName, createdType) {
 
-    private var _instance: T? = null
+    @Volatile private var _instance: T? = null
     private val _lock = Any()
 
     override fun getInstance(kodein: Kodein, key: Kodein.Key): T {
-        if (_instance != null)
-            return _instance!!
-        else
+        if(_instance == null) {
             synchronized(_lock) {
-                if (_instance == null)
-                    _instance = kodein.creator()
-                return _instance!!
+                if (_instance == null) _instance = kodein.creator()
             }
+        }
+        return _instance!!
     }
 }
 


### PR DESCRIPTION
WIP: Thought I'd take a crack at cleaning up some of the architecture. This PR isn't ready to be merged yet, but I though it would be good for discussion.

The next thing I want to work on is cleaning up `KodeinInjected` and `KodeinInjector`. Is there any specific reason `KodeinInjector` implements `KodeinInjected`?

  - Used @Volatile for properties involved in Double Checked Locking
  - Reversed the if checks to match DCL idiom