### PR TITLE
Detect recursive initialization in configurable module

### DIFF
--- a/kodein-conf/src/main/kotlin/com/github/salomonbrys/kodein/conf/ConfigurableKodein.kt
+++ b/kodein-conf/src/main/kotlin/com/github/salomonbrys/kodein/conf/ConfigurableKodein.kt
@@ -74,11 +74,13 @@ class ConfigurableKodein : Kodein {
             if (mutable == null)
                 mutable = false
 
+            val configs = checkNotNull(_configs) {"recursive initialization detected"}
+            _configs = null
+
             _instance = Kodein {
-                for (config in _configs!!)
+                for (config in configs)
                     config()
             }
-            _configs = null
 
             return _instance!!
         }


### PR DESCRIPTION
Detect StackOverflowError in the following case:
(Note `Kodein.global` reference in constructor and `eagerSingleton`)

    class Loop(text: String = Kodein.global.instance())

    val module = Kodein.Module {
        bind<String>() with singleton { "test" }
        bind<Loop>() with eagerSingleton { Loop() }
    }

    fun main(vararg args: String) {
        Kodein.global.addImport(module)
        Kodein.global.instance<Loop>()
    }


    Exception in thread "main" java.lang.StackOverflowError
        at TestKt$module$1.invoke(Test.kt)
        at TestKt$module$1.invoke(Test.kt)
        at com.github.salomonbrys.kodein.Kodein$Builder.<init>(Kodein.kt:303)
        at com.github.salomonbrys.kodein.Kodein$Builder.import(Kodein.kt:387)
        at com.github.salomonbrys.kodein.conf.ConfigurableKodein$addImport$1.invoke(ConfigurableKodein.kt:144)
        at com.github.salomonbrys.kodein.conf.ConfigurableKodein$addImport$1.invoke(ConfigurableKodein.kt:14)
        at com.github.salomonbrys.kodein.conf.ConfigurableKodein$getOrConstruct$$inlined$synchronized$lambda$1.invoke(ConfigurableKodein.kt:79)
        at com.github.salomonbrys.kodein.conf.ConfigurableKodein$getOrConstruct$$inlined$synchronized$lambda$1.invoke(ConfigurableKodein.kt:14)
        at com.github.salomonbrys.kodein.Kodein$Builder.<init>(Kodein.kt:303)
        at com.github.salomonbrys.kodein.internal.KodeinImpl.<init>(KodeinImpl.kt:34)
        at com.github.salomonbrys.kodein.Kodein$Companion.invoke(Kodein.kt:469)
        at com.github.salomonbrys.kodein.Kodein$Companion.invoke$default(Kodein.kt:469)
        at com.github.salomonbrys.kodein.conf.ConfigurableKodein.getOrConstruct(ConfigurableKodein.kt:77)
        at com.github.salomonbrys.kodein.conf.ConfigurableKodein.getTyped(ConfigurableKodein.kt:156)
        at Loop.<init>(Test.kt:20)
        at TestKt$module$1$2.invoke(Test.kt:8)
        at TestKt$module$1$2.invoke(Test.kt)
        at com.github.salomonbrys.kodein.ASingleton.getInstance(factories.kt:108)
        at com.github.salomonbrys.kodein.CEagerSingleton$1.invoke(factories.kt:159)
        at com.github.salomonbrys.kodein.CEagerSingleton$1.invoke(factories.kt:156)
        at com.github.salomonbrys.kodein.Kodein$Builder$onProviderReady$1.invoke(Kodein.kt:433)
        at com.github.salomonbrys.kodein.Kodein$Builder$onProviderReady$1.invoke(Kodein.kt:163)
        at com.github.salomonbrys.kodein.internal.KodeinImpl.<init>(KodeinImpl.kt:28)
        at com.github.salomonbrys.kodein.internal.KodeinImpl.<init>(KodeinImpl.kt:34)
        at com.github.salomonbrys.kodein.Kodein$Companion.invoke(Kodein.kt:469)
        at com.github.salomonbrys.kodein.Kodein$Companion.invoke$default(Kodein.kt:469)
        at com.github.salomonbrys.kodein.conf.ConfigurableKodein.getOrConstruct(ConfigurableKodein.kt:77)
        at com.github.salomonbrys.kodein.conf.ConfigurableKodein.getTyped(ConfigurableKodein.kt:156)
        at Loop.<init>(Test.kt:20)
        at TestKt$module$1$2.invoke(Test.kt:8)
        at TestKt$module$1$2.invoke(Test.kt)
        at com.github.salomonbrys.kodein.ASingleton.getInstance(factories.kt:108)
        at com.github.salomonbrys.kodein.CEagerSingleton$1.invoke(factories.kt:159)
        at com.github.salomonbrys.kodein.CEagerSingleton$1.invoke(factories.kt:156)
        at com.github.salomonbrys.kodein.Kodein$Builder$onProviderReady$1.invoke(Kodein.kt:433)
        at com.github.salomonbrys.kodein.Kodein$Builder$onProviderReady$1.invoke(Kodein.kt:163)
        at com.github.salomonbrys.kodein.internal.KodeinImpl.<init>(KodeinImpl.kt:28)
        at com.github.salomonbrys.kodein.internal.KodeinImpl.<init>(KodeinImpl.kt:34)
        at com.github.salomonbrys.kodein.Kodein$Companion.invoke(Kodein.kt:469)
        at com.github.salomonbrys.kodein.Kodein$Companion.invoke$default(Kodein.kt:469)
        at com.github.salomonbrys.kodein.conf.ConfigurableKodein.getOrConstruct(ConfigurableKodein.kt:77)
        at com.github.salomonbrys.kodein.conf.ConfigurableKodein.getTyped(ConfigurableKodein.kt:156)
        at Loop.<init>(Test.kt:20)
        at TestKt$module$1$2.invoke(Test.kt:8)
        at TestKt$module$1$2.invoke(Test.kt)
